### PR TITLE
change to species table to add links for name

### DIFF
--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -6,7 +6,7 @@
 class NbnRecords
 {
   const BASE_URL = 'https://records-ws.nbnatlas.org/';
-  public $data_resource_uid = 'dr'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
+  public $data_resource_uid = 'dr782'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
   public $facets;
   public $fsort;
   public $path = '';

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -6,7 +6,7 @@
 class NbnRecords
 {
   const BASE_URL = 'https://records-ws.nbnatlas.org/';
-  public $data_resource_uid = 'dr782'; // The SEDN data set
+  public $data_resource_uid = 'dr'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
   public $facets;
   public $fsort;
   public $path = '';

--- a/src/app/Views/species_search.php
+++ b/src/app/Views/species_search.php
@@ -76,17 +76,15 @@
             <th class="d-none d-md-table-cell">Family</th>
             <th>Scientific Name</th>
             <th class="d-none d-sm-table-cell">Common Name</th>
-            <th>Count</th>
             <th>Records</th>
         </tr></thead>
         <tbody>
         <?php foreach ($speciesList as $species):?>
         <tr>
             <td class="d-none d-md-table-cell"><?php echo $species->family?></td>
-            <td><?=$species->name?></td>
-            <td class="d-none d-sm-table-cell"><?php echo $species->commonName?></td>
+            <td><a href="<?php echo base_url("/species/{$species->name}");?>"><?=$species->name?></a></td>
+            <td class="d-none d-sm-table-cell"><a href="<?php echo base_url("/species/{$species->name}");?>"><?php echo $species->commonName?></a></td>
             <td><?=$species->count?></td>
-            <td><a href="<?php echo base_url("/species/{$species->name}");?>">see records</a></td>
         </tr>
         <?php endforeach;?>
         </tbody>


### PR DESCRIPTION
I've made two very small changes - front end change to make the initial species search table have links from the scientific and common names rather than the See Records links, as per the spec.  And I've added a comment to the NBNRecords class to suggest an alternative dataset to use while the SEDN data isn't available.