### PR TITLE
Docblocks and formatting on NbnRecords.php

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,8 @@
 	"editor.insertSpaces": false,
 	"editor.wordWrapColumn": 80,
 	"editor.rulers": [
-		80
+		80,
+		120
 	],
 	"rewrap.autoWrap.enabled": true,
 	"cSpell.words": ["axiophyte", "axiophytes", "fsort", "mapid", "mymap"],

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -3,17 +3,18 @@
 /**
  * Facade for the NBN records end point
  */
+
 class NbnRecords
 {
-	const BASE_URL          = 'https://records-ws.nbnatlas.org/';
-	public $dataResourceUid = 'dr1323'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
+	const BASE_URL           = 'https://records-ws.nbnatlas.org/';
+	private $dataResourceUid = 'dr1323'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
+	private $path     = '';
 	public $facets;
 	public $fsort;
-	public $path     = '';
 	public $pageSize = 9;
 	public $sort;
 
-	function __construct($path = 'occurrences/search')
+	public function __construct($path = 'occurrences/search')
 	{
 		$this->path = $path;
 	}
@@ -23,7 +24,7 @@ class NbnRecords
 	 *
 	 * @return string
 	 */
-	function getQueryString($url)
+	private function getQueryString($url)
 	{
 		$queryString  = $url . '?';
 		$queryString .= 'q=data_resource_uid:' . $this->dataResourceUid . '&';
@@ -37,7 +38,7 @@ class NbnRecords
 	/**
 	 * Return the base url and path (really only used for getting a single occurence record)
 	 */
-	function url()
+	protected function url()
 	{
 		return $this::BASE_URL . $this->path;
 	}
@@ -47,7 +48,7 @@ class NbnRecords
 	 *
 	 * @return string
 	 */
-	function getPagingQueryString()
+	public function getPagingQueryString()
 	{
 		$queryString  = $this->getQueryString($this::BASE_URL . $this->path);
 		$queryString .= 'pageSize=' . $this->pageSize;
@@ -59,7 +60,7 @@ class NbnRecords
 	 *
 	 * @return string
 	 */
-	function getDownloadQueryString()
+	public function getDownloadQueryString()
 	{
 		$queryString  = $this->getQueryString($this::BASE_URL . 'occurrences/index/download');
 		$queryString .= '&reasonTypeId=11&fileType=csv';

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -2,19 +2,82 @@
 
 /**
  * Facade for the NBN records end point
+ *
+ * See the NBN Atlas Query Primer for details about using the API
+ * https://docs.google.com/document/d/1FiVasGGZ3kRPnu5347GPAef7Tr5LvvghCS6x82xnfu4/edit
+ *
+ * @package Libraries
+ * @author  Careful Digital <hello@careful.digital>
+ * @license https://www.shropshirebotany.org.uk/ Shropshire Botanical Society
  */
 
 class NbnRecords
 {
-	const BASE_URL           = 'https://records-ws.nbnatlas.org/';
-	private $dataResourceUid = 'dr1323'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
-	private $path     = '';
+	const BASE_URL = 'https://records-ws.nbnatlas.org/';
+
+	/**
+	 * The unique data resource id code
+	 *
+	 * The id can by found by searching the NBN Atlas data sets at
+	 * https://registry.nbnatlas.org/datasets. The id is located in the URL of a
+	 * data resource page and consists of the letters "dr" followed by a number;
+	 * e.g., https://registry.nbnatlas.org/public/showDataResource/dr782
+	 *
+	 * dr782 is the SEDN data set.
+	 *
+	 * Use dr1323 for Worcestershire data if SEDN data not available:
+	 * https://registry.nbnatlas.org/public/showDataResource/dr1323
+	 *
+	 * @var string $dataResourceUid
+	 */
+	private $dataResourceUid = 'dr1323';
+
+	/**
+	 * TODO: Describe what the $path member variable is for
+	 *
+	 * @var string $path
+	 */
+	private $path = '';
+
+	/**
+	 * TODO: Describe what the $facets member variable is for
+	 *
+	 * @var string $facets
+	 */
 	public $facets;
+
+	/**
+	 * TODO: Describe what the $fsort member variable is for
+	 *
+	 * @var string $fsort
+	 */
 	public $fsort;
+
+	/**
+	 * TODO: Describe what the $pageSize member variable is for
+	 *
+	 * @var integer $pageSize
+	 */
 	public $pageSize = 9;
+
+	/**
+	 * TODO: Describe what the $sort member variable is for
+	 *
+	 * @var string $sort
+	 */
 	public $sort;
 
-	public function __construct($path = 'occurrences/search')
+	/**
+	 * Constructor
+	 *
+	 * Accepts a path fragment which indicates the NBN Atlas API search type to
+	 * perform. Defaults to Occurrence search: https://api.nbnatlas.org/#ws3
+	 *
+	 * See https://api.nbnatlas.org/ for others.
+	 *
+	 * @param string $path NBN Atlas API search type
+	 */
+	public function __construct(string $path = 'occurrences/search')
 	{
 		$this->path = $path;
 	}
@@ -22,9 +85,11 @@ class NbnRecords
 	/**
 	 * Return the base search query string
 	 *
+	 * @param string $url The full url to query
+	 *
 	 * @return string
 	 */
-	private function getQueryString($url)
+	private function getQueryString(string $url)
 	{
 		$queryString  = $url . '?';
 		$queryString .= 'q=data_resource_uid:' . $this->dataResourceUid . '&';
@@ -36,7 +101,10 @@ class NbnRecords
 	}
 
 	/**
-	 * Return the base url and path (really only used for getting a single occurence record)
+	 * Return the base url and path (really only used for getting a single
+	 * occurence record)
+	 *
+	 * @return string
 	 */
 	protected function url()
 	{
@@ -68,19 +136,28 @@ class NbnRecords
 	}
 
 	/**
-	 * @var string[]
+	 * Keeps an internal array of query filter parameters.
+	 *
+	 * A list of available index fields can be found at
+	 * https://species-ws.nbnatlas.org/admin/indexFields
+	 *
+	 * @var string[] Array of strings
 	 */
 	protected $filterQueryParameters = [];
 
 	/**
 	 * Adds to the internal list of filter query parameters
 	 *
+	 * A list of available index fields can be found at
+	 * https://species-ws.nbnatlas.org/admin/indexFields
+	 *
+	 * @param string $filterQueryParameter A single filter query parameter
+	 *
 	 * @return $this
 	 */
-	public function add($filterQueryParameter)
+	public function add(string $filterQueryParameter)
 	{
 		$this->filterQueryParameters[] = $filterQueryParameter;
 		return $this;
 	}
-
 }

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -3,85 +3,84 @@
 /**
  * Facade for the NBN records end point
  */
+
 class NbnRecords
 {
-  const BASE_URL = 'https://records-ws.nbnatlas.org/';
-  public $data_resource_uid = 'dr782'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
-  public $facets;
-  public $fsort;
-  public $path = '';
-  public $pageSize = 9;
-  public $sort;
+	const BASE_URL            = 'https://records-ws.nbnatlas.org/';
+	public $data_resource_uid = 'dr782'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
+	public $facets;
+	public $fsort;
+	public $path     = '';
+	public $pageSize = 9;
+	public $sort;
 
-  function __construct($path = 'occurrences/search') 
-  {
-    $this->path = $path;
-  }
+	function __construct($path = 'occurrences/search')
+	{
+		$this->path = $path;
+	}
 
+	/**
+	 * Return the base search query string
+	 *
+	 * @return string
+	 */
+	function getQueryString($url)
+	{
+		$query_string  = $url . '?';
+		$query_string .= 'q=data_resource_uid:' . $this->data_resource_uid . '&';
+		$query_string .= 'fq=' . implode('%20AND%20', $this->filter_query_parameters) . '&';
+		$query_string .= 'facets=' . $this->facets . '&';
+		$query_string .= 'sort=' . $this->sort . '&';
+		$query_string .= 'fsort=' . $this->fsort . '&';
+		return $query_string;
+	}
 
-  /**
-   * Return the base search query string
-   * 
-   * @return string
-   */
-  function getQueryString($url)
-  {
-    $query_string = $url.'?';
-    $query_string .= 'q=data_resource_uid:'.$this->data_resource_uid.'&';
-    $query_string .= 'fq='.implode("%20AND%20", $this->filter_query_parameters).'&';
-    $query_string .= 'facets='.$this->facets.'&';
-    $query_string .= 'sort='.$this->sort.'&';
-    $query_string .= 'fsort='.$this->fsort.'&';
-    return $query_string;
-  }
+	/**
+	 * Return the base url and path (really only used for getting a single occurence record)
+	 */
+	function url()
+	{
+		return $this::BASE_URL . $this->path;
+	}
 
-  /**
-   * Return the base url and path (really only used for getting a single occurence record)
-   */
-  function url()
-  {
-    return $this::BASE_URL.$this->path;
-  }
+	/**
+	 * Return the query string for paging
+	 *
+	 * @return string
+	 */
+	function getPagingQueryString()
+	{
+		$query_string  = $this->getQueryString($this::BASE_URL . $this->path);
+		$query_string .= 'pageSize=' . $this->pageSize;
+		return $query_string;
+	}
 
-  /**
-   * Return the query string for paging
-   * 
-   * @return string
-   */
-  function getPagingQueryString()
-  {
-    $query_string = $this->getQueryString($this::BASE_URL.$this->path);
-    $query_string .= 'pageSize='.$this->pageSize;
-    return $query_string;
-  }
+	/**
+	 * Return the query string for downloading the data
+	 *
+	 * @return string
+	 */
+	function getDownloadQueryString()
+	{
+		$query_string  = $this->getQueryString($this::BASE_URL . 'occurrences/index/download');
+		$query_string .= '&reasonTypeId=11&fileType=csv';
+		return $query_string;
+	}
 
-  /**
-   * Return the query string for downloading the data
-   * 
-   * @return string
-   */
-  function getDownloadQueryString()
-  {
-    $query_string = $this->getQueryString($this::BASE_URL.'occurrences/index/download');
-    $query_string .= '&reasonTypeId=11&fileType=csv';
-    return $query_string;
-  }
+	/**
+	 * @var string[]
+	 */
+	protected $filter_query_parameters = [];
 
-  /**
-   * @var string[]
-   */
-  protected $filter_query_parameters = array();
-
-  /**
-   * Adds to the internal list of filter query parameters
-   *
-   * @return $this
-   */
-  public function add($filter_query_parameter)
-  {
-      $this->filter_query_parameters[] = $filter_query_parameter;
-      return $this;
-  }
+	/**
+	 * Adds to the internal list of filter query parameters
+	 *
+	 * @return $this
+	 */
+	public function add($filter_query_parameter)
+	{
+		$this->filter_query_parameters[] = $filter_query_parameter;
+		return $this;
+	}
 
 }
-

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -106,7 +106,7 @@ class NbnRecords
 	 *
 	 * @return string
 	 */
-	protected function url()
+	public function url()
 	{
 		return $this::BASE_URL . $this->path;
 	}

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -3,11 +3,10 @@
 /**
  * Facade for the NBN records end point
  */
-
 class NbnRecords
 {
-	const BASE_URL            = 'https://records-ws.nbnatlas.org/';
-	public $data_resource_uid = 'dr782'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
+	const BASE_URL          = 'https://records-ws.nbnatlas.org/';
+	public $dataResourceUid = 'dr1323'; //  782=The SEDN data set.  Use 1323 for Worcestershire data if Shrop data not available
 	public $facets;
 	public $fsort;
 	public $path     = '';
@@ -26,13 +25,13 @@ class NbnRecords
 	 */
 	function getQueryString($url)
 	{
-		$query_string  = $url . '?';
-		$query_string .= 'q=data_resource_uid:' . $this->data_resource_uid . '&';
-		$query_string .= 'fq=' . implode('%20AND%20', $this->filter_query_parameters) . '&';
-		$query_string .= 'facets=' . $this->facets . '&';
-		$query_string .= 'sort=' . $this->sort . '&';
-		$query_string .= 'fsort=' . $this->fsort . '&';
-		return $query_string;
+		$queryString  = $url . '?';
+		$queryString .= 'q=data_resource_uid:' . $this->dataResourceUid . '&';
+		$queryString .= 'fq=' . implode('%20AND%20', $this->filterQueryParameters) . '&';
+		$queryString .= 'facets=' . $this->facets . '&';
+		$queryString .= 'sort=' . $this->sort . '&';
+		$queryString .= 'fsort=' . $this->fsort . '&';
+		return $queryString;
 	}
 
 	/**
@@ -50,9 +49,9 @@ class NbnRecords
 	 */
 	function getPagingQueryString()
 	{
-		$query_string  = $this->getQueryString($this::BASE_URL . $this->path);
-		$query_string .= 'pageSize=' . $this->pageSize;
-		return $query_string;
+		$queryString  = $this->getQueryString($this::BASE_URL . $this->path);
+		$queryString .= 'pageSize=' . $this->pageSize;
+		return $queryString;
 	}
 
 	/**
@@ -62,24 +61,24 @@ class NbnRecords
 	 */
 	function getDownloadQueryString()
 	{
-		$query_string  = $this->getQueryString($this::BASE_URL . 'occurrences/index/download');
-		$query_string .= '&reasonTypeId=11&fileType=csv';
-		return $query_string;
+		$queryString  = $this->getQueryString($this::BASE_URL . 'occurrences/index/download');
+		$queryString .= '&reasonTypeId=11&fileType=csv';
+		return $queryString;
 	}
 
 	/**
 	 * @var string[]
 	 */
-	protected $filter_query_parameters = [];
+	protected $filterQueryParameters = [];
 
 	/**
 	 * Adds to the internal list of filter query parameters
 	 *
 	 * @return $this
 	 */
-	public function add($filter_query_parameter)
+	public function add($filterQueryParameter)
 	{
-		$this->filter_query_parameters[] = $filter_query_parameter;
+		$this->filterQueryParameters[] = $filterQueryParameter;
 		return $this;
 	}
 

--- a/src/app/Libraries/NbnRecordsExamples.json
+++ b/src/app/Libraries/NbnRecordsExamples.json
@@ -13,16 +13,8 @@
 				"url": {
 					"raw": "https://records-ws.nbnatlas.org/explore/group/ALL_SPECIES?q=data_resource_uid:dr782&fq=taxon_name:Be* AND species_group:Plants Bryophytes&pageSize=9",
 					"protocol": "https",
-					"host": [
-						"records-ws",
-						"nbnatlas",
-						"org"
-					],
-					"path": [
-						"explore",
-						"group",
-						"ALL_SPECIES"
-					],
+					"host": ["records-ws", "nbnatlas", "org"],
+					"path": ["explore", "group", "ALL_SPECIES"],
 					"query": [
 						{
 							"key": "q",
@@ -49,15 +41,8 @@
 				"url": {
 					"raw": "https://records-ws.nbnatlas.org/occurrences/search?q=data_resource_uid:dr782&fq=taxon_name:Abies%20alba&sort=taxon_name&fsort=index&pageSize=9",
 					"protocol": "https",
-					"host": [
-						"records-ws",
-						"nbnatlas",
-						"org"
-					],
-					"path": [
-						"occurrences",
-						"search"
-					],
+					"host": ["records-ws", "nbnatlas", "org"],
+					"path": ["occurrences", "search"],
 					"query": [
 						{
 							"key": "q",
@@ -92,15 +77,8 @@
 				"url": {
 					"raw": "https://records-ws.nbnatlas.org/occurrences/search?q=data_resource_uid:dr782&fq=location_id:[Shrews%20TO%20*]&facets=location_id&pageSize=0",
 					"protocol": "https",
-					"host": [
-						"records-ws",
-						"nbnatlas",
-						"org"
-					],
-					"path": [
-						"occurrences",
-						"search"
-					],
+					"host": ["records-ws", "nbnatlas", "org"],
+					"path": ["occurrences", "search"],
 					"query": [
 						{
 							"key": "q",
@@ -136,16 +114,8 @@
 				"url": {
 					"raw": "https://records-ws.nbnatlas.org/explore/group/ALL_SPECIES?q=&fq=data_resource_uid:dr782+AND+location_id:Shrewsbury+AND+species_group:Plants+Bryophytes&pageSize=9",
 					"protocol": "https",
-					"host": [
-						"records-ws",
-						"nbnatlas",
-						"org"
-					],
-					"path": [
-						"explore",
-						"group",
-						"ALL_SPECIES"
-					],
+					"host": ["records-ws", "nbnatlas", "org"],
+					"path": ["explore", "group", "ALL_SPECIES"],
 					"query": [
 						{
 							"key": "q",
@@ -172,15 +142,8 @@
 				"url": {
 					"raw": "https://records-ws.nbnatlas.org/occurrences/search?fq=location_id:Bury%20Ditches&fq=data_resource_uid:dr782&fq=taxon_name:Saccogyna%20viticulosa&pageSize=9",
 					"protocol": "https",
-					"host": [
-						"records-ws",
-						"nbnatlas",
-						"org"
-					],
-					"path": [
-						"occurrences",
-						"search"
-					],
+					"host": ["records-ws", "nbnatlas", "org"],
+					"path": ["occurrences", "search"],
 					"query": [
 						{
 							"key": "fq",
@@ -211,11 +174,7 @@
 				"url": {
 					"raw": "https://records-ws.nbnatlas.org/occurrence/4276e1be-b7d2-46b0-a33d-6fa82e97636a?q=data_resource_uid:dr782&pageSize=9",
 					"protocol": "https",
-					"host": [
-						"records-ws",
-						"nbnatlas",
-						"org"
-					],
+					"host": ["records-ws", "nbnatlas", "org"],
 					"path": [
 						"occurrence",
 						"4276e1be-b7d2-46b0-a33d-6fa82e97636a"

--- a/src/app/Views/species_search.php
+++ b/src/app/Views/species_search.php
@@ -3,100 +3,102 @@
 <h2>Shropshire</h2>
 
 <?php echo form_open('species') ?>
-    <div class="form-group row">
-        <label for="search" class="col-sm-2 col-form-label d-none d-md-inline">Enter part of a species name</label>
-        <div class="col-sm-6">
-            <input type="text" class="form-control" name="search" id="search" 
-                aria-describedby="search-help" placeholder="Enter a species"
-                value="<?php echo set_value('search'); ?>" />
-            <small id="search-help" class="form-text text-muted d-none d-md-inline">Try something like "Hedera".</small>
-        </div>
-        <div class="col-sm-4">
-            <button type="submit" class="btn btn-primary">List Species</button>
-        </div>
-        </label>
-    </div>
-    <div class="form-group row">
-        <label for="in" class="col-md-2 col-form-label d-none d-md-inline">Search for</label>
-        <div class="col-md-10">
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="name-type"  id="scientific-name"
-                    value="scientific" <?php echo set_radio('name-type', 'scientific', TRUE); ?> />
-                <label class="form-check-label" for="scientific-name">
-                    scientific<span class="d-none d-md-inline"> name only</span>
-                </label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="name-type"  id="axiophyte-name"
-                    value="axiophyte" <?php echo set_radio('name-type', 'axiophyte'); ?> />
-                <label class="form-check-label" for="axiophyte-name">
-                    axiophyte<span class="d-none d-md-inline"> scientific name only</span>
-                </label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="name-type" id="common-name"
-                    value="common" <?php echo set_radio('name-type', 'common'); ?> />
-                <label class="form-check-label" for="common-name">
-                    common<span class="d-none d-md-inline"> name only</span>
-                </label>
-            </div>
-        </div>
-    </div>
-    <div class="form-group row">
-        <label for="in" class="col-md-2 col-form-label d-none d-md-inline">Groups</label>
-        <div class="col-md-10">
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="species-group"  id="plants"
-                    value="plants" <?php echo set_radio('groups', 'plants', TRUE); ?> />
-                <label class="form-check-label" for="scientific-name">
-                    only plants
-                </label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="species-group"  id="bryophytes"
-                    value="bryophytes" <?php echo set_radio('groups', 'bryophytes'); ?> />
-                <label class="form-check-label" for="axiophyte-name">
-                    only bryophytes
-                </label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="species-group" id="both"
-                    value="both" <?php echo set_radio('groups', 'both'); ?> />
-                <label class="form-check-label" for="common-name">
-                    both plants and bryophytes
-                </label>
-            </div>
-        </div>
-    </div>
+	<div class="form-group row">
+		<label for="search" class="col-sm-2 col-form-label d-none d-md-inline">Enter part of a species name</label>
+		<div class="col-sm-6">
+			<input type="text" class="form-control" name="search" id="search"
+				aria-describedby="search-help" placeholder="Enter a species"
+				value="<?php echo set_value('search'); ?>" />
+			<small id="search-help" class="form-text text-muted d-none d-md-inline">Try something like "Hedera".</small>
+		</div>
+		<div class="col-sm-4">
+			<button type="submit" class="btn btn-primary">List Species</button>
+		</div>
+		</label>
+	</div>
+	<div class="form-group row">
+		<label for="in" class="col-md-2 col-form-label d-none d-md-inline">Search for</label>
+		<div class="col-md-10">
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="radio" name="name-type"  id="scientific-name"
+					value="scientific" <?php echo set_radio('name-type', 'scientific', true); ?> />
+				<label class="form-check-label" for="scientific-name">
+					scientific<span class="d-none d-md-inline"> name only</span>
+				</label>
+			</div>
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="radio" name="name-type"  id="axiophyte-name"
+					value="axiophyte" <?php echo set_radio('name-type', 'axiophyte'); ?> />
+				<label class="form-check-label" for="axiophyte-name">
+					axiophyte<span class="d-none d-md-inline"> scientific name only</span>
+				</label>
+			</div>
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="radio" name="name-type" id="common-name"
+					value="common" <?php echo set_radio('name-type', 'common'); ?> />
+				<label class="form-check-label" for="common-name">
+					common<span class="d-none d-md-inline"> name only</span>
+				</label>
+			</div>
+		</div>
+	</div>
+	<div class="form-group row">
+		<label for="in" class="col-md-2 col-form-label d-none d-md-inline">Groups</label>
+		<div class="col-md-10">
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="radio" name="species-group"  id="plants"
+					value="plants" <?php echo set_radio('groups', 'plants', true); ?> />
+				<label class="form-check-label" for="scientific-name">
+					only plants
+				</label>
+			</div>
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="radio" name="species-group"  id="bryophytes"
+					value="bryophytes" <?php echo set_radio('groups', 'bryophytes'); ?> />
+				<label class="form-check-label" for="axiophyte-name">
+					only bryophytes
+				</label>
+			</div>
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="radio" name="species-group" id="both"
+					value="both" <?php echo set_radio('groups', 'both'); ?> />
+				<label class="form-check-label" for="common-name">
+					both plants and bryophytes
+				</label>
+			</div>
+		</div>
+	</div>
 <?php echo form_close() ?>
 <!-- Show the search results if there are any -->
 <?php if (isset($speciesList)):?>
-    <table class="table">
-        <thead><tr>
-            <th class="d-none d-md-table-cell">Family</th>
-            <th>Scientific Name</th>
-            <th class="d-none d-sm-table-cell">Common Name</th>
-            <th>Records</th>
-        </tr></thead>
-        <tbody>
-        <?php foreach ($speciesList as $species):?>
-        <tr>
-            <td class="d-none d-md-table-cell"><?php echo $species->family?></td>
-            <td><a href="<?php echo base_url("/species/{$species->name}");?>"><?=$species->name?></a></td>
-            <td class="d-none d-sm-table-cell"><a href="<?php echo base_url("/species/{$species->name}");?>"><?php echo $species->commonName?></a></td>
-            <td><?=$species->count?></td>
-        </tr>
-        <?php endforeach;?>
-        </tbody>
-    </table>
-    <nav>
-        <ul class="pagination justify-content-center">
-            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-            <li class="page-item"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
-            <li class="page-item"><a class="page-link" href="#">Next</a></li>
-        </ul>
-    </nav>
+	<table class="table">
+		<thead><tr>
+			<th class="d-none d-md-table-cell">Family</th>
+			<th>Scientific Name</th>
+			<th class="d-none d-sm-table-cell">Common Name</th>
+			<th>Records</th>
+		</tr></thead>
+		<tbody>
+		<?php foreach ($speciesList as $species):?>
+		<tr>
+			<td class="d-none d-md-table-cell"><?php echo $species->family?></td>
+			<td><a href="<?php echo base_url('/species/' . $species->name); ?>"><?php echo $species->name ?></a></td>
+			<td class="d-none d-sm-table-cell">
+				<a href="<?php echo base_url('/species/' . $species->name); ?>"><?php echo $species->commonName ?></a>
+			</td>
+			<td><?php echo $species->count ?></td>
+		</tr>
+		<?php endforeach;?>
+		</tbody>
+	</table>
+	<nav>
+		<ul class="pagination justify-content-center">
+			<li class="page-item"><a class="page-link" href="#">Previous</a></li>
+			<li class="page-item"><a class="page-link" href="#">1</a></li>
+			<li class="page-item"><a class="page-link" href="#">2</a></li>
+			<li class="page-item"><a class="page-link" href="#">3</a></li>
+			<li class="page-item"><a class="page-link" href="#">Next</a></li>
+		</ul>
+	</nav>
 <?php endif ?>
 <?php echo $this->endSection() ?>


### PR DESCRIPTION
This PR relates to #35.

I have done some work on cleaning up a file (NbnRecords.php) and adding WIP docblocks (as per PHPCS rules). 

Adding docblocks have proved to be useful for two reasons:

1. Adding them helps one understand what the class/function/method actually does. In describing it, you need to understand it.

2. PHP docblocks are recognised by VSCode and provide useful in-place docs when hovering over variable names and instances of objects. Will add a couple of screenshots.

The PHP DocBlocker, Better Comments, and Rewrap extensions are *really* useful for working with docblocks.

A few other things included in this PR:

- A added type hints
- Changed variable names from snake_case to camelCase
- Added visibility declarations (public, protected, private)
- Misc formatting and spacing

The json file and `species_search.php` view included in this PR are minor "testers" to see what the formatter would do.

Next step after this is to work on the Views and look to start on #14 and #27. I'll create a new branch off this one for that.

I will leave the Models and Controllers alone for now to avoid creating any merge conflicts with work on other branches.