### PR TITLE
correcting start parameter on API query

### DIFF
--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -127,7 +127,7 @@ class NbnRecords
 	public function getPagingQueryStringWithStart($start)
 	{
 		$pagingQuery = $this->getPagingQueryString();
-		return $pagingQuery .= "&start=" . $start;
+		return $pagingQuery .= "&start=" . (($start - 1) * $this->pageSize);
 	}
 
 	/**


### PR DESCRIPTION
This is an important correction - I'd misintrepreted the way the start parameter worked within the NBN API (thinking it was start page not start record.  Results make more sense now :)