### PR TITLE
4.2.2 map showing location of the site with a pin 62

### DIFF
--- a/src/app/Controllers/Records.php
+++ b/src/app/Controllers/Records.php
@@ -25,6 +25,7 @@ class Records extends BaseController
 		$records = $this->nbn->getSingleSpeciesRecordsForCounty($speciesName,$this->page);
         $this->data['download_link'] = $records->downloadLink;
         $this->data['recordsList']   = $records->records;
+		$this->data['sites']         = $records->sites;
 		$this->data['page']          = $this->page;
 		$this->data['queryUrl']      = $records->queryUrl;
 		$this->data['totalRecords']  = $records->totalRecords;

--- a/src/app/Controllers/Records.php
+++ b/src/app/Controllers/Records.php
@@ -1,64 +1,66 @@
-<?php namespace App\Controllers;
+<?php
+
+namespace App\Controllers;
 
 /**
  * Manage the records views.
  */
 class Records extends BaseController
 {
-    private $data = array('title' => 'Records');
+	private $data = ['title' => 'Records'];
 
-    /**
-     * List the records for a species in the entire dataset
-     */
-    public function singleSpeciesForCounty($speciesName)
-    {
-        $this->data['site_name'] = "Shropshire";
-		$this->data['title'] = urldecode($speciesName);
+	/**
+	 * List the records for a species in the entire dataset
+	 */
+	public function singleSpeciesForCounty($speciesName)
+	{
+		$this->data['site_name'] = "Shropshire";
+		$this->data['title']     = urldecode($speciesName);
 		if (isset($_GET['name']))
 		{
 			$this->data['speciesName'] = $_GET['name'];
 		}
 		else
 		{
-        	$this->data['speciesName'] = $speciesName;
+			$this->data['speciesName'] = $speciesName;
 		}
-		$records = $this->nbn->getSingleSpeciesRecordsForCounty($speciesName,$this->page);
-        $this->data['download_link'] = $records->downloadLink;
-        $this->data['recordsList']   = $records->records;
+		$records                     = $this->nbn->getSingleSpeciesRecordsForCounty($speciesName, $this->page);
+		$this->data['download_link'] = $records->downloadLink;
+		$this->data['recordsList']   = $records->records;
 		$this->data['sites']         = $records->sites;
 		$this->data['page']          = $this->page;
 		$this->data['queryUrl']      = $records->queryUrl;
 		$this->data['totalRecords']  = $records->totalRecords;
 		$this->data['totalPages']    = $records->getTotalPages();
-        echo view('species_records', $this->data);
-    }
+		echo view('species_records', $this->data);
+	}
 
-    /**
-     * Display records for a single species for a site
-     */
-    public function singleSpeciesForSite($site_name, $Nme)
-    {
-        // Map of site
-        $this->data['site_name'] = $site_name;
-        $this->data['Nme'] = $Nme;
-        $this->data['records_list'] = $this->nbn->getSingleSpeciesRecordsForSite($site_name, $Nme);
-        echo view('species_records', $this->data);
-    }
+	/**
+	 * Display records for a single species for a site
+	 */
+	public function singleSpeciesForSite($site_name, $Nme)
+	{
+		// Map of site
+		$this->data['site_name']    = $site_name;
+		$this->data['Nme']          = $Nme;
+		$this->data['records_list'] = $this->nbn->getSingleSpeciesRecordsForSite($site_name, $Nme);
+		echo view('species_records', $this->data);
+	}
 
-    /**
-     * Display a single record
-     */
-    public function singleRecord($uuid)
-    {
-        $record = $this->nbn->getSingleOccurenceRecord($uuid);
-        $occurrence = $record->processed->occurrence;
-        $this->data['occurrence'] = $occurrence;
-        $classification = $record->processed->classification;
-        $this->data['classification'] = $classification;
-        $title = $classification->scientificName."-".$occurrence->recordedBy;
-        $this->data['location'] = $record->raw->location; # `raw` contains the locationID
-        $this->data['event'] = $record->processed->event;
-        $this->data['title'] = $title;
-        echo view('single_record', $this->data);
-    }
+	/**
+	 * Display a single record
+	 */
+	public function singleRecord($uuid)
+	{
+		$record                       = $this->nbn->getSingleOccurenceRecord($uuid);
+		$occurrence                   = $record->processed->occurrence;
+		$this->data['occurrence']     = $occurrence;
+		$classification               = $record->processed->classification;
+		$this->data['classification'] = $classification;
+		$title                        = $classification->scientificName . "-" . $occurrence->recordedBy;
+		$this->data['location']       = $record->raw->location; # `raw` contains the locationID
+		$this->data['event']          = $record->processed->event;
+		$this->data['title']          = $title;
+		echo view('single_record', $this->data);
+	}
 }

--- a/src/app/Controllers/Species.php
+++ b/src/app/Controllers/Species.php
@@ -59,6 +59,7 @@ class Species extends BaseController
 		$this->data['title']            = $this->data['title'] . " - " . $name_search_string;
 		$speciesQueryResult             = $this->nbn->getSpeciesListForCounty($name_search_string, $name_type, $species_group, $this->page);
 		$this->data['speciesList']      = $speciesQueryResult->records;
+		$this->data['sites']            = $speciesQueryResult->sites;
 		$this->data['downloadLink']     = $speciesQueryResult->downloadLink;
 		$this->data['queryUrl']         = $speciesQueryResult->queryUrl;
 		$this->data['nameSearchString'] = $name_search_string;

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -1,4 +1,6 @@
-<?php namespace App\Models;
+<?php
+
+namespace App\Models;
 
 use App\Libraries\NbnRecords;
 
@@ -69,14 +71,13 @@ class NbnQuery implements NbnQueryInterface
 	public function getSingleSpeciesRecordsForCounty($speciesName, $page)
 	{
 		// mainly to replace the spaces with %20
-		$speciesName       = rawurlencode($speciesName);
-		$nbnRecords        = new NbnRecords('occurrences/search');
-		$nbnRecords->sort  = "year";
+		$speciesName      = rawurlencode($speciesName);
+		$nbnRecords       = new NbnRecords('occurrences/search');
+		$nbnRecords->sort = "year";
+		$nbnRecords->dir  = "desc";
 		// $nbnRecords->fsort = "index";
-		$nbnRecords->dir   = "desc";
 		$nbnRecords
-			->add('taxon_name:' . '"' . $speciesName . '"')
-		;
+			->add('taxon_name:' . '"' . $speciesName . '"');
 		$queryUrl           = $nbnRecords->getPagingQueryStringWithStart($page);
 		$recordsJson        = file_get_contents($queryUrl);
 		$recordsJsonDecoded = json_decode($recordsJson);
@@ -124,8 +125,7 @@ class NbnQuery implements NbnQueryInterface
 		$nbn_records->facets   = "location_id";
 		$nbn_records->pageSize = 0;
 		$nbn_records
-			->add('location_id:[' . $site_search_string . '%20TO%20*]')
-		;
+			->add('location_id:[' . $site_search_string . '%20TO%20*]');
 		$query_url  = $nbn_records->getPagingQueryString();
 		$sites_json = file_get_contents($query_url);
 		$sites_list = json_decode($sites_json)->facetResults[0]->fieldResult;
@@ -143,8 +143,7 @@ class NbnQuery implements NbnQueryInterface
 		$nbn_records = new NbnRecords('explore/group/ALL_SPECIES');
 		$nbn_records
 			->add('location_id:' . urlencode($site_name))
-			->add('species_group:Plants+Bryophytes')
-		;
+			->add('species_group:Plants+Bryophytes');
 		$query_url         = $nbn_records->getPagingQueryString();
 		$species_json      = file_get_contents($query_url);
 		$site_species_list = json_decode($species_json);
@@ -165,5 +164,4 @@ class NbnQuery implements NbnQueryInterface
 	{
 		return null;
 	}
-
 }

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -87,14 +87,25 @@ class NbnQuery implements NbnQueryInterface
 			return $b->year <=> $a->year;
 		});
 
+		$sites = [];
 		foreach ($recordList as $record)
 		{
 			$record->locationId = $record->locationId ?? '';
 			$record->collector  = $record->collector ?? 'Unknown';
+
+			// To plot site markers on the map, we must capture the locationId
+			// (site name) and latLong of only the _first_ record for each site.
+			// The latLong returned from the API is a single string, so we
+			// convert into an array of two floats.
+			if (! array_key_exists($record->locationId, $sites))
+			{
+				$sites[$record->locationId] = array_map('floatval', explode(",", $record->latLong));
+			}
 		}
 
 		$speciesQueryResult               = new NbnQueryResult();
 		$speciesQueryResult->records      = $recordList;
+		$speciesQueryResult->sites        = $sites;
 		$speciesQueryResult->downloadLink = $nbnRecords->getDownloadQueryString();
 		$speciesQueryResult->totalRecords = $totalRecords;
 		$speciesQueryResult->queryUrl     = $queryUrl;

--- a/src/app/Models/NbnQueryCached.php
+++ b/src/app/Models/NbnQueryCached.php
@@ -1,4 +1,7 @@
-<?php namespace App\Models;
+<?php
+
+namespace App\Models;
+
 use CodeIgniter\Model;
 
 /**
@@ -18,7 +21,7 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	private const CACHE_ACTIVE = false;
 
 	/**
-	 * Constructor, initiliases NbnQuery
+	 * Constructor, initialises NbnQuery
 	 *
 	 * @access public
 	 */
@@ -30,17 +33,18 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache the search for species within the county
 	 *
-	 * @param [string] $nameSearchString the species name
-	 * @param [string] $nameType         scientific or common
-	 * @param [string] $speciesGroup     plants, bryophytes or both
-	 * @param int      $page             the page of results to return
+	 * @param string  $nameSearchString The species name
+	 * @param string  $nameType         Scientific or common
+	 * @param string  $speciesGroup     Plants, bryophytes or both
+	 * @param int     $page             The page of results to return
 	 *
-	 * @return nbnQueryResult
+	 * @return NbnQueryResult
 	 */
 	public function getSpeciesListForCounty($nameSearchString, $nameType, $speciesGroup, $page)
 	{
-		$nameSearchString = ucfirst($nameSearchString); //because the API respects the case
-		$cacheName         = "get-species-list-for-county-$nameType-$speciesGroup-$nameSearchString-$page";
+		//because the API respects the case
+		$nameSearchString = ucfirst($nameSearchString);
+		$cacheName        = "get-species-list-for-county-$nameType-$speciesGroup-$nameSearchString-$page";
 		if (! self::CACHE_ACTIVE || ! $speciesList = cache($cacheName))
 		{
 			$speciesList = $this->nbnQuery->getSpeciesListForCounty($nameSearchString, $nameType, $speciesGroup, $page);
@@ -55,16 +59,17 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache the single species search within the county
 	 *
-	 * @param [string] $speciesName the name of the species
+	 * @param string $speciesName The name of the species
+	 * @param string $page        The page of results to return
 	 *
-	 * @return nbnQueryResult
+	 * @return NbnQueryResult
 	 */
 	public function getSingleSpeciesRecordsForCounty($speciesName, $page)
 	{
 		$cacheName = "get-single-species-for-county-$speciesName-$page";
 		if (! self::CACHE_ACTIVE || ! $speciesRecords = cache($cacheName))
 		{
-			$speciesRecords = $this->nbnQuery->getSingleSpeciesRecordsForCounty($speciesName,$page);
+			$speciesRecords = $this->nbnQuery->getSingleSpeciesRecordsForCounty($speciesName, $page);
 			if (self::CACHE_ACTIVE)
 			{
 				cache()->save($cacheName, $speciesRecords, CACHE_LIFE);
@@ -76,9 +81,9 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache the single occurence record
 	 *
-	 * @param [string] $uuid the unique id for the occurence
+	 * @param string $uuid the unique id for the occurence
 	 *
-	 * @return [nbnQueryResult]
+	 * @return NbnQueryResult
 	 */
 	public function getSingleOccurenceRecord($uuid)
 	{
@@ -97,9 +102,9 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache the site list for the county
 	 *
-	 * @param [string] $siteSearchString the name of the site
+	 * @param string $siteSearchString The name of the site
 	 *
-	 * @return [nbnQueryResult]
+	 * @return NbnQueryResult
 	 */
 	public function getSiteListForCounty($siteSearchString)
 	{
@@ -119,10 +124,10 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache for site speciest list
 	 *
-	 * @param [string] $sitename     the name of the site
-	 * @param [string] $speciesGroup plants, bryophytes or both
+	 * @param string $siteName     The name of the site
+	 * @param string $speciesGroup Plants, bryophytes or both
 	 *
-	 * @return nbnQueryResult
+	 * @return NbnQueryResult
 	 */
 	public function getSpeciesListForSite($siteName, $speciesGroup)
 	{
@@ -132,7 +137,7 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 			$speciesList = $this->nbnQuery->getSpeciesListForSite($siteName, $speciesGroup);
 			if (self::CACHE_ACTIVE)
 			{
-				 cache()->save($cacheName, $speciesList, CACHE_LIFE);
+				cache()->save($cacheName, $speciesList, CACHE_LIFE);
 			}
 		}
 		return $speciesList;
@@ -141,10 +146,10 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache the single species record for a site
 	 *
-	 * @param [string] $siteName    the site name
-	 * @param [string] $speciesName the species name
+	 * @param string $siteName    The site name
+	 * @param string $speciesName The species name
 	 *
-	 * @return [nbnQueryResult]
+	 * @return NbnQueryResult
 	 */
 	public function getSingleSpeciesRecordsForSite($siteName, $speciesName)
 	{
@@ -163,12 +168,12 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache species list for square
 	 *
-	 * @param [string] $gridSquare   the grid square
-	 * @param [string] $speciesGroup plants, bryophytes or both
+	 * @param string $gridSquare   The grid square
+	 * @param string $speciesGroup Plants, bryophytes or both
 	 *
-	 * @return [nbnQueryResult]
+	 * @return NbnQueryResult
 	 *
-	 * @TODO: implement speciesGroup filtering
+	 * TODO: implement speciesGroup filtering
 	 */
 	public function getSpeciesListForSquare($gridSquare, $speciesGroup)
 	{
@@ -178,7 +183,7 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 			$speciesList = $this->nbnQuery->getSpeciesListForSquare($gridSquare);
 			if (self::CACHE_ACTIVE)
 			{
-				 cache()->save($cacheName, $speciesList, CACHE_LIFE);
+				cache()->save($cacheName, $speciesList, CACHE_LIFE);
 			}
 		}
 		return $speciesList;
@@ -187,10 +192,10 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 	/**
 	 * Cache for single species record in square
 	 *
-	 * @param [string] $gridSquare  the grid square
-	 * @param [string] $speciesName the species name
+	 * @param string $gridSquare  The grid square
+	 * @param string $speciesName The species name
 	 *
-	 * @return nbnQueryResult
+	 * @return NbnQueryResult
 	 */
 	public function getSingleSpeciesRecordsForSquare($gridSquare, $speciesName)
 	{
@@ -200,7 +205,7 @@ class NbnQueryCached extends Model implements NbnQueryInterface
 			$speciesRecords = $this->nbnQuery->getSingleSpeciesRecordsForSquare($gridSquare, $speciesName);
 			if (self::CACHE_ACTIVE)
 			{
-				 cache()->save($cacheName, $speciesRecords, CACHE_LIFE);
+				cache()->save($cacheName, $speciesRecords, CACHE_LIFE);
 			}
 		}
 		return $speciesRecords;

--- a/src/app/Models/NbnQueryInterface.php
+++ b/src/app/Models/NbnQueryInterface.php
@@ -1,15 +1,17 @@
-<?php namespace App\Models;
+<?php
+
+namespace App\Models;
 
 interface NbnQueryInterface
 {
-  public function getSpeciesListForCounty($name_search_string, $name_type, $species_group,$page);
-  public function getSingleSpeciesRecordsForCounty($species_name, $page);
-  public function getSingleOccurenceRecord($uuid);
+	public function getSpeciesListForCounty($name_search_string, $name_type, $species_group, $page);
+	public function getSingleSpeciesRecordsForCounty($species_name, $page);
+	public function getSingleOccurenceRecord($uuid);
 
-  public function getSiteListForCounty($site_search_string);
-  public function getSpeciesListForSite($site_name, $species_group);
-  public function getSingleSpeciesRecordsForSite($site_name, $species_name);
+	public function getSiteListForCounty($site_search_string);
+	public function getSpeciesListForSite($site_name, $species_group);
+	public function getSingleSpeciesRecordsForSite($site_name, $species_name);
 
-  public function getSpeciesListForSquare($grid_square, $species_group);
-  public function getSingleSpeciesRecordsForSquare($grid_square, $species_name);
+	public function getSpeciesListForSquare($grid_square, $species_group);
+	public function getSingleSpeciesRecordsForSquare($grid_square, $species_name);
 }

--- a/src/app/Models/NbnQueryResult.php
+++ b/src/app/Models/NbnQueryResult.php
@@ -5,6 +5,7 @@ namespace App\Models;
 class NbnQueryResult
 {
 	public $records;
+	public $sites;
 	public $downloadLink;
 	public $totalRecords;
 	public $queryUrl;

--- a/src/app/Models/NbnQueryResult.php
+++ b/src/app/Models/NbnQueryResult.php
@@ -1,5 +1,6 @@
-<?php namespace App\Models;
+<?php
 
+namespace App\Models;
 
 class NbnQueryResult
 {
@@ -8,10 +9,9 @@ class NbnQueryResult
 	public $totalRecords;
 	public $queryUrl;
 
-
 	public function getTotalPages()
 	{
 		$limit = 10; //per page
-		return ceil( $this->totalRecords / $limit ); //calculate total pages
+		return ceil($this->totalRecords / $limit); //calculate total pages
 	}
 }

--- a/src/app/Views/species_records.php
+++ b/src/app/Views/species_records.php
@@ -140,6 +140,13 @@
 			map.fitBounds(boundary.getBounds(geojson).pad(0.1));
 		});
 
+	// Plot the sites to the map as markers
+	const sites = <?= json_encode($sites) ?>;
+	const siteMarkers = Object.entries(sites).map(site => {
+		return L.marker([...site[1]]).bindPopup(site[0]);
+	});
+	L.layerGroup([...siteMarkers]).addTo(map);
+
 	// When the page loads or on resize, we check whether we are on small screen
 	// or large. If on large - >= 992px - we remove the tabs; if on small, we
 	// them again.


### PR DESCRIPTION
This relates to #62 

Adds site markers to the map that correspond to the first record for each unique site name.

Note, this now makes #60 not true: the site markers are clickable. We have to do this for now because the markers will otherwise be meaningless. A useful enhancement would be to highlight markers when hovering over data rows. This would need to be just an enhancement and not the sole way of indicating what the marker represents because a) hovering doesn't work on touch, and b) the data and map are on tabs on small screens and you need both on screen at same time to make the hovering UI pattern work.