### PR TITLE
UI/UX problems with map, site pins, and data 103

### DIFF
--- a/src/app/Views/species_records.php
+++ b/src/app/Views/species_records.php
@@ -143,9 +143,10 @@
 	// Plot the sites to the map as markers
 	const sites = <?= json_encode($sites) ?>;
 	const siteMarkers = Object.entries(sites).map(site => {
-		return L.marker(site[1]).bindPopup(site[0]);
+		return L.circleMarker(site[1]).bindTooltip(site[0]);
 	});
-	L.layerGroup([...siteMarkers]).addTo(map);
+	// Turn off rendering of sites for now
+	// L.layerGroup([...siteMarkers]).addTo(map);
 
 	// When the page loads or on resize, we check whether we are on small screen
 	// or large. If on large - >= 992px - we remove the tabs; if on small, we

--- a/src/app/Views/species_records.php
+++ b/src/app/Views/species_records.php
@@ -140,6 +140,24 @@
 			map.fitBounds(boundary.getBounds(geojson).pad(0.1));
 		});
 
+	// Plot page of records on the map with tooltips
+	const records = <?= json_encode($recordsList) ?>;
+
+	const recordMarkers = records.map(record => {
+		const lat = record.decimalLatitude;
+		const lng = record.decimalLongitude;
+		return L.circleMarker([lat, lng], {
+			fillColor: "red",
+			color: "darkRed",
+			fillOpacity: .75
+		}).bindTooltip(`
+			${record.locationId} (${record.gridReference})<br>
+			${record.collector}<br>
+		`);
+	});
+
+	L.layerGroup(recordMarkers).addTo(map);
+
 	// Plot the sites to the map as markers
 	const sites = <?= json_encode($sites) ?>;
 	const siteMarkers = Object.entries(sites).map(site => {

--- a/src/app/Views/species_records.php
+++ b/src/app/Views/species_records.php
@@ -143,7 +143,7 @@
 	// Plot the sites to the map as markers
 	const sites = <?= json_encode($sites) ?>;
 	const siteMarkers = Object.entries(sites).map(site => {
-		return L.marker([...site[1]]).bindPopup(site[0]);
+		return L.marker(site[1]).bindPopup(site[0]);
 	});
 	L.layerGroup([...siteMarkers]).addTo(map);
 

--- a/src/app/Views/species_records.php
+++ b/src/app/Views/species_records.php
@@ -45,7 +45,7 @@
 				</thead>
 				<tbody>
 					<?php foreach ($recordsList as $record) : ?>
-						<tr>
+						<tr data-uuid="<?= $record->uuid ?>">
 							<td>
 								<a href="/site/<?= $record->locationId ?>/group/plants/type/scientific">
 									<?= $record->locationId ?>
@@ -146,16 +146,46 @@
 	const recordMarkers = records.map(record => {
 		const lat = record.decimalLatitude;
 		const lng = record.decimalLongitude;
-		return L.circleMarker([lat, lng], {
+
+		const marker = L.circleMarker([lat, lng], {
 			fillColor: "red",
 			color: "darkRed",
 			fillOpacity: .75
-		}).bindTooltip(`
+		});
+
+		marker.uuid = record.uuid;
+
+		marker.bindPopup(`
 			${record.locationId} (${record.gridReference})<br>
 			${record.collector}<br>
 		`);
-	});
 
+		// Events for hovering over markers
+		// marker.on("mouseover", (event) => {
+		// 	const highlightRow = document.querySelector(`[data-uuid="${event.target.uuid}"]`);
+		// 	highlightRow.style.backgroundColor = 'rgb(255, 255, 0, 0.5)';
+		// });
+
+		// marker.on("mouseout", (event) => {
+		// 	const highlightRow = document.querySelector(`[data-uuid="${event.target.uuid}"]`);
+		// 	highlightRow.style.backgroundColor = 'initial';
+		// })
+
+		// When we open a popup also highlight the corresponding row in the data
+		// table. This is _essential_ for orientation when using tabs on small
+		// screens
+		marker.on("popupopen", (event) => {
+			const highlightRow = document.querySelector(`[data-uuid="${event.target.uuid}"]`);
+			highlightRow.style.backgroundColor = 'rgb(255, 255, 0, 0.5)';
+		});
+
+		marker.on("popupclose", (event) => {
+			const highlightRow = document.querySelector(`[data-uuid="${event.target.uuid}"]`);
+			highlightRow.style.backgroundColor = 'initial';
+		})
+
+		return marker;
+	});
 	L.layerGroup(recordMarkers).addTo(map);
 
 	// Plot the sites to the map as markers


### PR DESCRIPTION
Relates to issue #103, #62, 

This improves the rendering of markers.

I have turned off **site** markers for now because rendering sites for one page of data doesn't make much sense: in any given page of data, the site is only very rarely repeated. As it turns out, each record in a page also represents a unique site in almost every instance.

So, instead, it makes much more sense to render each of the records for the current page of data.

Each record can be clicked or tapped and a popup will appear showing the site, grid reference, and recorder(s). When a popup is showing, the corresponding row in the data is highlighted. This helps guide the user to clicking the right _Site_, _Square_, or _More_ link. It also helps the user understand what data relates to what dot, which is **essential** when in responsive tabbed mode.

Aside: It would perhaps make more sense to render *all* sites instead of just some, but this could result in thousands of markers to render, which is extremely slow and almost impossible to use or visually parse. This would require some thinking to make work and, to be honest, I'm not sure what the user need is (yet).

So I suggest we go with this for now until we know more and/or better understand the user need. It does, for almost every page, satisfy the spec (#62). **To be on the safe site, is it worth asking for further clarification on #62?**

As it stands, showing a highlighted set of 10 (seemingly arbitrary) records on the screen doesn't feel all _that_ useful unless there are only very few records on the screen. This is because paging through thousands of records to inspect the results of a query feels unwieldy. My gut feeling is that it would be more useful to show the map with the squares on for all records, then the user could select records on the map to drill into the data (e.g., drag select a box or click on a square to return just those records). I have a hunch ShropBotSoc will have ideas along similar lines once we show the thing to them.

Here's a gif for visual reference of what this PR is doing:

![shropbot-record-popups](https://user-images.githubusercontent.com/176/115321875-afa86f00-a17c-11eb-84c5-36227500043b.gif)
