### PR TITLE
Changing queries

### DIFF
--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -75,6 +75,13 @@ class NbnRecords
 	public $dir = 'asc';
 
 	/**
+	 * TODO: Describe what the $flimit variable is for
+	 *
+	 * @var int $flimit
+	 */
+	public $flimit;
+
+	/**
 	 * Constructor
 	 *
 	 * Accepts a path fragment which indicates the NBN Atlas API search type to
@@ -105,6 +112,12 @@ class NbnRecords
 		$queryString .= 'sort=' . $this->sort . '&';
 		$queryString .= 'fsort=' . $this->fsort . '&';
 		$queryString .= 'dir=' . $this->dir . '&';
+
+		if (isset($this->flimit))
+		{
+			$queryString .= 'flimit=' . $this->flimit . '&';
+		}
+
 		return $queryString;
 	}
 

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -151,6 +151,13 @@ class NbnRecords
 		return $pagingQuery .= "&start=" . (($start - 1) * $this->pageSize);
 	}
 
+	public function getPagingQueryStringWithFacetStart($start)
+	{
+		$pagingQuery = $this->getPagingQueryString();
+		return $pagingQuery .= "&facet.offset=" . (($start - 1) * $this->pageSize);
+	}
+
+
 	/**
 	 * Return the query string for downloading the data
 	 *

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -37,10 +37,9 @@ class NbnQuery implements NbnQueryInterface
 		{
 			$speciesGroup = ucfirst($speciesGroup);
 		}
-		$nbnRecords = new NbnRecords('/occurrences/search');
-		$nbnRecords->facets= 'common_name_and_lsid';
-
-
+		$nbnRecords           = new NbnRecords('/occurrences/search');
+		$nbnRecords->facets   = 'common_name_and_lsid';
+		$nbnRecords->pageSize = 0;
 
 		if ($nameType === "scientific")
 		{
@@ -61,7 +60,7 @@ class NbnQuery implements NbnQueryInterface
 		$speciesList      = json_decode($speciesListJson);
 
 		$speciesQueryResult               = new NbnQueryResult();
-		$speciesQueryResult->records      = $speciesList;
+		$speciesQueryResult->records      = $speciesList->facetResults[0]->fieldResult;
 		$speciesQueryResult->downloadLink = $nbnRecords->getDownloadQueryString();
 		$speciesQueryResult->queryUrl     = $queryUrl;
 		return $speciesQueryResult;

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -45,14 +45,14 @@ class NbnQuery implements NbnQueryInterface
 		if ($nameType === "scientific")
 		{
 			$nbnRecords
-				->add('taxon_name:' . str_replace(" ", "+%2B", $nameSearchString) . '*')
+				->add('taxon_name:' . $this->prepareSearchString($nameSearchString))
 				->sort = "taxon_name";
 		}
 
 		if ($nameType === "common")
 		{
 			$nbnRecords
-				->add('common_name:' . str_replace(" ", "+%2B", $nameSearchString) . '*')
+				->add('common_name:' . $this->prepareSearchString($nameSearchString))
 				->sort = "common_name";
 		}
 		$nbnRecords->add('species_group:' . $speciesGroup);
@@ -61,7 +61,7 @@ class NbnQuery implements NbnQueryInterface
 		$speciesList         = json_decode($speciesListJson);
 		$speciesQueryResult  = new NbnQueryResult();
 
-		if (count($speciesList->facetResults) > 0)
+		if (isset($speciesList->facetResults))
 		{
 			$speciesQueryResult->records = $speciesList->facetResults[0]->fieldResult;
 		}
@@ -193,5 +193,31 @@ class NbnQuery implements NbnQueryInterface
 	public function getSingleSpeciesRecordsForSquare($grid_square, $species_name)
 	{
 		return null;
+	}
+
+	/**
+	 * Deals with multi-word search terms and prepares
+	 * theme for use by the NBN API by adding ANDs
+	 *
+	 * @param string $searchString the search term to prepare
+	 *
+	 * @return string the prepared search search name
+	 */
+	private function prepareSearchString($searchString)
+	{
+
+		$searchWords  = explode(' ', $searchString);
+		if (count($searchWords) === 1)
+		{
+			return $searchString;
+		}
+		$preparedSearchString = $searchWords[0] . '*';
+		unset($searchWords[0]);
+		foreach ($searchWords as $searchWord)
+		{
+			$preparedSearchString .= ' AND '. $searchWord;
+		}
+		$preparedSearchString = str_replace(' ', '+%2B', $preparedSearchString);
+		return $preparedSearchString;
 	}
 }

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -57,7 +57,7 @@ class NbnQuery implements NbnQueryInterface
 		}
 		$nbnRecords->add('species_group:' . $speciesGroup);
 		$queryUrl            = $nbnRecords->getPagingQueryStringWithFacetStart($page);
-		$nbnQueryResponse  = $this->callNbnApi($query_url);
+		$nbnQueryResponse  = $this->callNbnApi($queryUrl);
 		$speciesQueryResult  = new NbnQueryResult();
 
 		if ($nbnQueryResponse->status === 'OK')

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -17,14 +17,17 @@ class NbnQuery implements NbnQueryInterface
 	 *
 	 * e.g. https://records-ws.nbnatlas.org/explore/group/ALL_SPECIES?q=data_resource_uid:dr782&fq=taxon_name:B* AND species_group:Plants Bryophytes&pageSize=9&sort=
 	 *
+	 * Changing to use:
+	 * https://records-ws.nbnatlas.org/occurrences/search?facets=common_name_and_lsid&q=data_resource_uid:dr782&flimit=-1&fq=common_name:Ivy*%20AND%20species_group:Plants+Bryophytes&fsort=index&pageSize=0
+	 *
 	 * TODO: Search in common names
 	 * TODO: Search on axiophytes
 	 * TODO: Only plants, only bryophytes or both
 	 */
-	public function getSpeciesListForCounty($name_search_string, $nameType, $speciesGroup, $page)
+	public function getSpeciesListForCounty($nameSearchString, $nameType, $speciesGroup, $page)
 	{
 		//because the API respects the case
-		$name_search_string = ucfirst($name_search_string);
+		$nameSearchString = ucfirst($nameSearchString);
 
 		if ($speciesGroup === "both")
 		{
@@ -34,30 +37,30 @@ class NbnQuery implements NbnQueryInterface
 		{
 			$speciesGroup = ucfirst($speciesGroup);
 		}
-		$nbn_records = new NbnRecords('explore/group/ALL_SPECIES');
+		$nbnRecords = new NbnRecords('explore/group/ALL_SPECIES');
 
 		if ($nameType === "scientific")
 		{
-			$nbn_records
-				->add('taxon_name:' . str_replace(" ", "+%2B", $name_search_string) . '*')
+			$nbnRecords
+				->add('taxon_name:' . str_replace(" ", "+%2B", $nameSearchString) . '*')
 				->sort = "taxon_name";
 		}
 
 		if ($nameType === "common")
 		{
-			$nbn_records
-				->add('common_name:' . str_replace(" ", "+%2B", $name_search_string) . '*')
+			$nbnRecords
+				->add('common_name:' . str_replace(" ", "+%2B", $nameSearchString) . '*')
 				->sort = "common_name";
 		}
-		$nbn_records->add('species_group:' . $speciesGroup);
-		$query_url         = $nbn_records->getPagingQueryStringWithStart($page);
-		$species_list_json = file_get_contents($query_url);
-		$species_list      = json_decode($species_list_json);
+		$nbnRecords->add('species_group:' . $speciesGroup);
+		$queryUrl         = $nbnRecords->getPagingQueryStringWithStart($page);
+		$speciesListJson = file_get_contents($queryUrl);
+		$speciesList      = json_decode($speciesListJson);
 
 		$speciesQueryResult               = new NbnQueryResult();
-		$speciesQueryResult->records      = $species_list;
-		$speciesQueryResult->downloadLink = $nbn_records->getDownloadQueryString();
-		$speciesQueryResult->queryUrl     = $query_url;
+		$speciesQueryResult->records      = $speciesList;
+		$speciesQueryResult->downloadLink = $nbnRecords->getDownloadQueryString();
+		$speciesQueryResult->queryUrl     = $queryUrl;
 		return $speciesQueryResult;
 	}
 

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -39,7 +39,8 @@ class NbnQuery implements NbnQueryInterface
 		}
 		$nbnRecords           = new NbnRecords('/occurrences/search');
 		$nbnRecords->facets   = 'common_name_and_lsid';
-		$nbnRecords->pageSize = 0;
+		$nbnRecords->flimit   = '10';
+		//$nbnRecords->pageSize = 10;
 
 		if ($nameType === "scientific")
 		{
@@ -55,14 +56,22 @@ class NbnQuery implements NbnQueryInterface
 				->sort = "common_name";
 		}
 		$nbnRecords->add('species_group:' . $speciesGroup);
-		$queryUrl         = $nbnRecords->getPagingQueryStringWithStart($page);
-		$speciesListJson = file_get_contents($queryUrl);
-		$speciesList      = json_decode($speciesListJson);
+		$queryUrl            = $nbnRecords->getPagingQueryStringWithFacetStart($page);
+		$speciesListJson     = file_get_contents($queryUrl);
+		$speciesList         = json_decode($speciesListJson);
+		$speciesQueryResult  = new NbnQueryResult();
 
-		$speciesQueryResult               = new NbnQueryResult();
-		$speciesQueryResult->records      = $speciesList->facetResults[0]->fieldResult;
-		$speciesQueryResult->downloadLink = $nbnRecords->getDownloadQueryString();
-		$speciesQueryResult->queryUrl     = $queryUrl;
+		if (count($speciesList->facetResults) > 0)
+		{
+			$speciesQueryResult->records = $speciesList->facetResults[0]->fieldResult;
+		}
+		else
+		{
+			$speciesQueryResult->records = [];
+		}
+			$speciesQueryResult->downloadLink = $nbnRecords->getDownloadQueryString();
+			$speciesQueryResult->queryUrl     = $queryUrl;
+
 		return $speciesQueryResult;
 	}
 

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -37,7 +37,10 @@ class NbnQuery implements NbnQueryInterface
 		{
 			$speciesGroup = ucfirst($speciesGroup);
 		}
-		$nbnRecords = new NbnRecords('explore/group/ALL_SPECIES');
+		$nbnRecords = new NbnRecords('/occurrences/search');
+		$nbnRecords->facets= 'common_name_and_lsid';
+
+
 
 		if ($nameType === "scientific")
 		{

--- a/src/app/Views/species_search.php
+++ b/src/app/Views/species_search.php
@@ -76,11 +76,12 @@
 		</thead>
 		<tbody>
 			<?php foreach ($speciesList as $species) : ?>
+				<?php $speciesArray = explode('|', (string)$species->label); ?>
 				<tr>
-					<td class="d-none d-md-table-cell"><?= $species->family ?></td>
-					<td><a href="<?= base_url('/species/' . $species->name) ?>"><?= $species->name ?></a></td>
+					<td class="d-none d-md-table-cell"><?= $speciesArray[5] ?></td>
+					<td><a href="<?= base_url('/species/' . $speciesArray[1]) ?>"><?= $speciesArray[1] ?></a></td>
 					<td class="d-none d-sm-table-cell">
-						<a href="<?= base_url('/species/' . $species->name . '?name=' . $species->commonName) ?>"><?= $species->commonName ?></a>
+						<a href="<?= base_url('/species/' . $speciesArray[0] . '?name=' . $speciesArray[0]) ?>"><?= $speciesArray[0] ?></a>
 					</td>
 					<td><?= $species->count ?></td>
 				</tr>

--- a/src/app/Views/species_search.php
+++ b/src/app/Views/species_search.php
@@ -59,9 +59,7 @@
 	</div>
 </div>
 <?= form_close() ?>
-<?php if (isset($downloadLink)) : ?>
-	<p><a href="<?= $downloadLink ?>">Download this data</a></p>
-<?php endif ?>
+
 
 <?php if (isset($message)) : ?>
 	<div class="alert alert-danger" role="alert">
@@ -70,7 +68,10 @@
 <?php endif ?>
 
 <!-- Show the search results if there are any -->
-<?php if (isset($speciesList)) : ?>
+<?php if (isset($speciesList)&&count($speciesList)>0) : ?>
+	<?php if (isset($downloadLink)) : ?>
+	<p><a href="<?= $downloadLink ?>">Download this data</a></p>
+	<?php endif ?>
 	<table class="table mt-3">
 		<thead>
 			<tr>
@@ -87,7 +88,7 @@
 					<td class="d-none d-md-table-cell"><?= $speciesArray[5] ?></td>
 					<td><a href="<?= base_url('/species/' . $speciesArray[1]) ?>"><?= $speciesArray[1] ?></a></td>
 					<td class="d-none d-sm-table-cell">
-						<a href="<?= base_url('/species/' . $speciesArray[0] . '?name=' . $speciesArray[0]) ?>"><?= $speciesArray[0] ?></a>
+						<a href="<?= base_url('/species/' . $speciesArray[1] . '?name=' . $speciesArray[0]) ?>"><?= $speciesArray[0] ?></a>
 					</td>
 					<td><?= $species->count ?></td>
 				</tr>
@@ -107,7 +108,10 @@
 	<?php if (isset($downloadLink)) : ?>
 		<p><a href="<?= $downloadLink ?>">Download this data</a></p>
 	<?php endif ?>
-
+<?php else: ?>
+	<div class="alert alert-warning" role="alert">
+		No records could be found matching those criteria.
+	</div>
 <?php endif ?>
 
 <?= $this->endSection() ?>


### PR DESCRIPTION
I've replaced the query used in 	public function getSpeciesListForCounty($nameSearchString, $nameType, $speciesGroup, $page)

It was https://records-ws.nbnatlas.org/explore/group/ALL_SPECIES?q=data_resource_uid:dr782&fq=taxon_name:B* AND species_group:Plants Bryophytes&pageSize=9&sort=

It is now https://records-ws.nbnatlas.org/occurrences/search?facets=common_name_and_lsid&q=data_resource_uid:dr782&flimit=-1&fq=common_name:Ivy*%20AND%20species_group:Plants+Bryophytes&fsort=index&pageSize=0

This now uses a facet search - I've had to make quite a few changes to enable this - added better facet handling to NBNRecords and changing the view - as the name results are now in a lcid field..

Good things:  multiname searching now works - sort of.  You can search for exact multiname matches, e.g. http://localhost:8089/species/Hedera%20helix/group/both/type/scientific

But multiname inexact matches don't work so well, e.g. http://localhost:8089/species/Hoary%20Ragwort/group/both/type/common - because it is doing an OR.  Need to change the query to use ANDs and only do a starts with search on the first word, e.g.

https://records-ws.nbnatlas.org//occurrences/search?q=data_resource_uid:dr782&fq=common_name:Hoary*+AND+Ragwort%20AND%20species_group:Plants+Bryophytes&facets=common_name_and_lsid&sort=common_name&fsort=&dir=asc&flimit=10&pageSize=10&facet.offset=0

And because of the facet query, we can't order results by scientific/common name any more, as requested - they come back in order of occurences.  Which may be ok/actually quite helpful, but may be a big issue.