### PR TITLE
getting true no of records from API

### DIFF
--- a/src/app/Controllers/Species.php
+++ b/src/app/Controllers/Species.php
@@ -67,6 +67,7 @@ class Species extends BaseController
 		$this->data['nameType']     = $name_type;
 		$this->data['speciesGroup'] = $species_group;
 		$this->data['page'] = $this->page;
+		$this->data['totalRecords'] = $speciesQueryResult->totalRecords;
 		$this->data['totalPages']       = $speciesQueryResult->getTotalPages();
 
 		set_cookie("speciesNameSearch",$name_search_string,"3600", "localhost", "/", "", false, false, null);

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -134,6 +134,21 @@ class NbnRecords
 	}
 
 	/**
+	 * Return the query string without paging
+	 * Used to determine total number of records for query
+	 * without paging
+	 *
+	 * @return string
+	 */
+	public function getUnpagedQueryString()
+	{
+		$queryString  = $this->getQueryString($this::BASE_URL . $this->path);
+		$queryString .= 'pageSize=0&flimit=-1';
+		return $queryString;
+	}
+
+
+	/**
 	 * Return the query string for paging
 	 *
 	 * @return string

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -57,7 +57,7 @@ class NbnQuery implements NbnQueryInterface
 		}
 		$nbnRecords           = new NbnRecords('/occurrences/search');
 		$nbnRecords->facets   = 'common_name_and_lsid';
-		$nbnRecords->flimit   = '10';
+
 		//$nbnRecords->pageSize = 10;
 
 		if ($nameType === "scientific")
@@ -74,6 +74,15 @@ class NbnQuery implements NbnQueryInterface
 				->sort = "common_name";
 		}
 		$nbnRecords->add('species_group:' . $speciesGroup);
+
+		$queryUrl            = $nbnRecords->getUnpagedQueryString();
+		$nbnQueryResponse    = $this->callNbnApi($queryUrl);
+		$totalRecords 		 = 0;
+		if (isset($nbnQueryResponse->jsonResponse->facetResults[0]))
+		{
+			$totalRecords = count($nbnQueryResponse->jsonResponse->facetResults[0]->fieldResult);
+		}
+		$nbnRecords->flimit   = '10';
 		$queryUrl            = $nbnRecords->getPagingQueryStringWithFacetStart($page);
 		$nbnQueryResponse = $this->callNbnApi($queryUrl);
 
@@ -90,7 +99,8 @@ class NbnQuery implements NbnQueryInterface
 		{
 			if (isset($nbnQueryResponse->jsonResponse->facetResults[0]))
 			{
-				$speciesQueryResult->records = $nbnQueryResponse->jsonResponse->facetResults[0]->fieldResult;
+				$speciesQueryResult->records = 	$nbnQueryResponse->jsonResponse->facetResults[0]->fieldResult;
+
 			}
 			else
 			{
@@ -99,9 +109,10 @@ class NbnQuery implements NbnQueryInterface
 			}
 			$speciesQueryResult->downloadLink = $nbnRecords->getDownloadQueryString();
 		}
-		$speciesQueryResult->status   = $nbnQueryResponse->status;
-		$speciesQueryResult->message  = $nbnQueryResponse->message;
+		$speciesQueryResult->status   	  = $nbnQueryResponse->status;
+		$speciesQueryResult->message  	  = $nbnQueryResponse->message;
 		$speciesQueryResult->queryUrl     = $queryUrl;
+		$speciesQueryResult->totalRecords = $totalRecords;
 		return $speciesQueryResult;
 	}
 

--- a/src/app/Views/species_search.php
+++ b/src/app/Views/species_search.php
@@ -97,14 +97,47 @@
 	</table>
 	<nav>
 		<ul class="pagination justify-content-center">
-			<?php if ($page > 1) : ?>
-				<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page - 1) ?>">Previous</a></li>
-			<?php endif ?>
-			<?php if (count($speciesList) === 10) : ?>
-				<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page + 1) ?>">Next</a></li>
-			<?php endif ?>
-		</ul>
-	</nav>
+	<?php
+	$range = 3;
+	if ($page + $range >7) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=1' ?>">First</a></li>
+	<?php endif ?>
+	<?php if ($page > 1) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page - 1) ?>">Previous</a></li>
+	<?php endif ?>
+	<?php
+		for ($x = ($page - $range); $x < (($page + $range) + 1); $x++)
+		{
+			if (($x > 0) && ($x <= $totalPages))
+			{
+				if ($x === $page)
+				{
+					?>
+
+			<li class="page-item"><span class="page-link" style="font-color:#000000;"><?= $x?></span></li>
+		<?php
+				}
+				else
+				{
+					?>
+ 			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . $x?> "><?= $x?></a></li>
+		<?php
+			}
+		}
+	} ?>
+	<?php
+	if ($page<$totalPages) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page+1) ?>">Next</a></li>
+	<?php endif ?>
+	<?php
+	if (($page + $range)<$totalPages) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' .$totalPages?>">Last</a></li>
+	<?php endif ?>
+	</ul>
+	<p class="text-center" style="font-size:small;"><?= $totalRecords ?> records in <?= $totalPages ?> pages </p>
+</nav>
+
+
 	<?php if (isset($downloadLink)) : ?>
 		<p><a href="<?= $downloadLink ?>">Download this data</a></p>
 	<?php endif ?>


### PR DESCRIPTION
This took some work! :)

I followed Sophia's advice and used the occurrence search with a facet is, e.g. https://records-ws.nbnatlas.org/occurrences/search?facets=common_name_and_lsid&q=data_resource_uid:dr782&flimit=-1&fq=common_name:Ivy*%20AND%20species_group:Plants+Bryophytes&fsort=index&pageSize=0

This has to be run before the actual paged facet search to get the total number of records.  So you end up with two API calls, which isn't ideal but does the expected result.

As part of this pull request, I've also improved the pagination for the species search - it now includes First and Last links whenever this makes sense to display.  I intend to add this to the Species Record search too, but going forward we should figure out how to make the pagination a View Partial so we can reuse it across views.