### PR TITLE
pagination as partial view on species record page

### DIFF
--- a/src/app/Controllers/Species.php
+++ b/src/app/Controllers/Species.php
@@ -58,7 +58,7 @@ class Species extends BaseController
 	{
 		$this->data['title']            = $this->data['title'] . " - " . $name_search_string;
 		$speciesQueryResult             = $this->nbn->getSpeciesListForCounty($name_search_string, $name_type, $species_group, $this->page);
-		$this->data['speciesList']      = $speciesQueryResult->records;
+		$this->data['records']      = $speciesQueryResult->records;
 		$this->data['sites']            = $speciesQueryResult->sites;
 		$this->data['downloadLink']     = $speciesQueryResult->downloadLink;
 		$this->data['queryUrl']         = $speciesQueryResult->queryUrl;

--- a/src/app/Views/pagination.php
+++ b/src/app/Views/pagination.php
@@ -1,0 +1,41 @@
+<nav>
+		<ul class="pagination justify-content-center">
+	<?php
+	$range = 3;
+	if ($page + $range >7) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=1' ?>">First</a></li>
+	<?php endif ?>
+	<?php if ($page > 1) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page - 1) ?>">Previous</a></li>
+	<?php endif ?>
+	<?php
+		for ($x = ($page - $range); $x < (($page + $range) + 1); $x++)
+		{
+			if (($x > 0) && ($x <= $totalPages))
+			{
+				if ($x === $page)
+				{
+					?>
+
+			<li class="page-item"><span class="page-link" style="font-color:#000000;"><?= $x?></span></li>
+		<?php
+				}
+				else
+				{
+					?>
+ 			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . $x?> "><?= $x?></a></li>
+		<?php
+			}
+		}
+	} ?>
+	<?php
+	if ($page<$totalPages) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page+1) ?>">Next</a></li>
+	<?php endif ?>
+	<?php
+	if (($page + $range)<$totalPages) : ?>
+			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' .$totalPages?>">Last</a></li>
+	<?php endif ?>
+	</ul>
+	<p class="text-center" style="font-size:small;"><?= $totalRecords ?> records in <?= $totalPages ?> pages </p>
+</nav>

--- a/src/app/Views/species_records.php
+++ b/src/app/Views/species_records.php
@@ -233,37 +233,8 @@
 		});
 	});
 </script>
-<nav>
-	<ul class="pagination justify-content-center">
-		<?php if ($page > 1) : ?>
-			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page - 1) ?>">Previous</a></li>
-		<?php endif ?>
-		<?php
-		$range = 3;
-		for ($x = ($page - $range); $x < (($page + $range) + 1); $x++)
-		{
-			if (($x > 0) && ($x <= $totalPages))
-			{
-				if ($x === $page)
-				{
-					?>
 
-			<li class="page-item"><span class="page-link" style="font-color:#000000;"><?= $x?></span></li>
-		<?php
-				}
-				else
-				{
-					?>
- 			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . $x?> "><?= $x?></a></li>
-		<?php
-			}
-		}
-	} ?>
-		<?php if (count($recordsList) === 10) : ?>
-			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page + 1) ?>">Next</a></li>
-		<?php endif ?>
-	</ul>
-</nav>
+<?= $this->include('pagination') ?>
 
 	<?php if (isset($download_link)) : ?>
 <p><a href="<?= $download_link ?>">Download this data</a></p>

--- a/src/app/Views/species_search.php
+++ b/src/app/Views/species_search.php
@@ -68,7 +68,7 @@
 <?php endif ?>
 
 <!-- Show the search results if there are any -->
-<?php if (isset($speciesList)&&count($speciesList)>0) : ?>
+<?php if (isset($records)&&count($records)>0) : ?>
 	<?php if (isset($downloadLink)) : ?>
 	<p><a href="<?= $downloadLink ?>">Download this data</a></p>
 	<?php endif ?>
@@ -82,7 +82,7 @@
 			</tr>
 		</thead>
 		<tbody>
-			<?php foreach ($speciesList as $species) : ?>
+			<?php foreach ($records as $species) : ?>
 				<?php $speciesArray = explode('|', (string)$species->label); ?>
 				<tr>
 					<td class="d-none d-md-table-cell"><?= $speciesArray[5] ?></td>
@@ -95,48 +95,7 @@
 			<?php endforeach ?>
 		</tbody>
 	</table>
-	<nav>
-		<ul class="pagination justify-content-center">
-	<?php
-	$range = 3;
-	if ($page + $range >7) : ?>
-			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=1' ?>">First</a></li>
-	<?php endif ?>
-	<?php if ($page > 1) : ?>
-			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page - 1) ?>">Previous</a></li>
-	<?php endif ?>
-	<?php
-		for ($x = ($page - $range); $x < (($page + $range) + 1); $x++)
-		{
-			if (($x > 0) && ($x <= $totalPages))
-			{
-				if ($x === $page)
-				{
-					?>
-
-			<li class="page-item"><span class="page-link" style="font-color:#000000;"><?= $x?></span></li>
-		<?php
-				}
-				else
-				{
-					?>
- 			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . $x?> "><?= $x?></a></li>
-		<?php
-			}
-		}
-	} ?>
-	<?php
-	if ($page<$totalPages) : ?>
-			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' . ($page+1) ?>">Next</a></li>
-	<?php endif ?>
-	<?php
-	if (($page + $range)<$totalPages) : ?>
-			<li class="page-item"><a class="page-link" href="<?= current_url() . '?page=' .$totalPages?>">Last</a></li>
-	<?php endif ?>
-	</ul>
-	<p class="text-center" style="font-size:small;"><?= $totalRecords ?> records in <?= $totalPages ?> pages </p>
-</nav>
-
+	<?= $this->include('pagination') ?>
 
 	<?php if (isset($downloadLink)) : ?>
 		<p><a href="<?= $downloadLink ?>">Download this data</a></p>


### PR DESCRIPTION
I've added a pagination partial view - this can be added to a view by using <?= $this->include('pagination') ?>

I've added the partial view to the species search and records pages.

To use the pagination partial view, the controller needs to pass in the following to the view.  Page and totalPages are automated, the key is to get the totalRecords field populated correctly - this may be retrievable as part of the JSON response for the query, or may need a separate preliminary query to retrieve.

		$this->data['page']         = $this->page;
		$this->data['totalRecords'] = $records->totalRecords;
		$this->data['totalPages']   = $records->getTotalPages();
