### PR TITLE
adding download link to single species page

### DIFF
--- a/src/app/Controllers/Records.php
+++ b/src/app/Controllers/Records.php
@@ -114,6 +114,8 @@ class Records extends BaseController
 			$this->data['fullDate'] = $fullDate;
 
 			$this->data['recordId']       = $record->records->processed->rowKey;
+
+			$this->data['download_link']    = $record->downloadLink;
 		}
 		$this->data['status']  = $record->status;
 		$this->data['message'] = $record->message;

--- a/src/app/Libraries/NbnRecords.php
+++ b/src/app/Libraries/NbnRecords.php
@@ -121,6 +121,24 @@ class NbnRecords
 		return $queryString;
 	}
 
+
+	/**
+	 * Return the url for single record download querty
+	 *
+	 * @param string $url The full url to query
+	 *
+	 * @return string
+	 */
+	private function getSingleRecordDownloadUrl(string $url, string $occurrenceId)
+	{
+		$queryString  = $url . '?';
+		$queryString .= 'fq=occurrence_id:' .$occurrenceId . '&';
+
+
+		return $queryString;
+	}
+
+
 	/**
 	 * Return the base url and path (really only used for getting a single
 	 * occurence record)
@@ -182,6 +200,18 @@ class NbnRecords
 	{
 		$queryString  = $this->getQueryString($this::BASE_URL . 'occurrences/index/download');
 		$queryString .= '&reasonTypeId=11&fileType=csv';
+		return $queryString;
+	}
+
+		/**
+	 * Return the query string for downloading the data
+	 *
+	 * @return string
+	 */
+	public function getSingleRecordDownloadQueryString($occurrenceId)
+	{
+		$queryString  = $this->getSingleRecordDownloadUrl($this::BASE_URL . 'occurrences/index/download',$occurrenceId);
+		$queryString .= '&reasonTypeId=11';
 		return $queryString;
 	}
 

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -186,11 +186,14 @@ class NbnQuery implements NbnQueryInterface
 		if ($nbnQueryResponse->status === 'OK')
 		{
 			$singleOccurenceResult->records      = $nbnQueryResponse->jsonResponse;
-			$singleOccurenceResult->downloadLink = $nbnRecords->getDownloadQueryString();
+			//$singleOccurenceResult->downloadLink = $nbnRecords->getDownloadQueryString();
 		}
 		$singleOccurenceResult->status   = $nbnQueryResponse->status;
 		$singleOccurenceResult->message  = $nbnQueryResponse->message;
 		$singleOccurenceResult->queryUrl = $queryUrl;
+
+		$nbnRecord = new NbnRecords("occurrences/index/download");
+		$singleOccurenceResult->downloadLink = $nbnRecords->getSingleRecordDownloadQueryString($singleOccurenceResult->records->raw->occurrence->occurrenceID);
 		return $singleOccurenceResult;
 	}
 

--- a/src/app/Views/single_record.php
+++ b/src/app/Views/single_record.php
@@ -148,5 +148,10 @@
 			});
 		});
 	</script>
+
+	<?php if (isset($download_link)) : ?>
+<p><a href="<?= $download_link ?>">Download this data</a></p>
+	<?php endif ?>
+
 <?php endif ?>
 <?= $this->endSection() ?>


### PR DESCRIPTION
This involved changing the standard download link API query to use https://records-ws.nbnatlas.org/occurrences/index/download as suggested by Sophia.